### PR TITLE
Add HCIS admin role management hooks

### DIFF
--- a/wp-content/plugins/hcis.ysq/hcis.ysq.php
+++ b/wp-content/plugins/hcis.ysq/hcis.ysq.php
@@ -75,9 +75,10 @@ require_once HCISYSQ_DIR . 'includes/Hcis_Gas_Token.php';
 require_once HCISYSQ_DIR . 'includes/Legacy_Admin_Bridge.php';
 
 /* =======================================================
- *  Activation (create tables)
+ *  Activation / Deactivation hooks
  * ======================================================= */
 register_activation_hook(__FILE__, ['HCISYSQ\\Installer', 'activate']);
+register_deactivation_hook(__FILE__, ['HCISYSQ\\Installer', 'deactivate']);
 
 /* =======================================================
  *  Init modules

--- a/wp-content/plugins/hcis.ysq/includes/Installer.php
+++ b/wp-content/plugins/hcis.ysq/includes/Installer.php
@@ -72,7 +72,47 @@ class Installer {
       wp_schedule_event(time() + 600, 'daily', 'hcisysq_users_cron');
     }
 
+    self::add_roles_and_capabilities();
+
     Publikasi::on_activation();
     Tasks::on_activation();
+  }
+
+  public static function deactivate(){
+    self::remove_roles_and_capabilities();
+  }
+
+  protected static function add_roles_and_capabilities(){
+    if (!function_exists('add_role') || !function_exists('get_role')) {
+      return;
+    }
+
+    $role = get_role('hcis_admin');
+    if (!$role) {
+      add_role('hcis_admin', 'HCIS Admin', [
+        'read' => true,
+        'manage_hcis_portal' => true,
+      ]);
+      $role = get_role('hcis_admin');
+    }
+
+    if ($role) {
+      $role->add_cap('read', true);
+      $role->add_cap('manage_hcis_portal', true);
+    }
+  }
+
+  protected static function remove_roles_and_capabilities(){
+    if (!function_exists('remove_role') || !function_exists('get_role')) {
+      return;
+    }
+
+    $role = get_role('hcis_admin');
+    if ($role) {
+      $role->remove_cap('manage_hcis_portal');
+      $role->remove_cap('read');
+    }
+
+    remove_role('hcis_admin');
   }
 }


### PR DESCRIPTION
## Summary
- ensure the installer registers an HCIS Admin role with manage_hcis_portal capability on activation
- add cleanup of the custom role during plugin deactivation and register the new hook

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e54618c2688323a6ee070f88e75a1f