### PR TITLE
Add HCIS portal menu and prioritize WordPress admin authentication

### DIFF
--- a/wp-content/plugins/hcis.ysq/includes/Admin.php
+++ b/wp-content/plugins/hcis.ysq/includes/Admin.php
@@ -4,14 +4,38 @@ namespace HCISYSQ;
 if (!defined('ABSPATH')) exit;
 
 class Admin {
-  public static function menu(){
-    add_management_page(
+  public static function menu() {
+    // 1. Keep the old settings page, but hook it to 'add_options_page' for consistency.
+    add_options_page(
       'HCIS.YSQ Settings',
       'HCIS.YSQ Settings',
       'manage_options',
       'hcisysq-settings',
-      [__CLASS__,'render']
+      [__CLASS__, 'render']
     );
+
+    // 2. Add the new main admin portal page.
+    add_menu_page(
+      'Portal HCIS',
+      'Portal HCIS',
+      'manage_hcis_portal',
+      'hcis-admin-portal',
+      [__CLASS__, 'render_admin_portal_page'],
+      'dashicons-groups',
+      25
+    );
+  }
+
+  /**
+   * Render the view for the new "Portal HCIS" admin page.
+   */
+  public static function render_admin_portal_page() {
+    ?>
+    <div class="wrap">
+      <h1>Welcome to the HCIS Portal</h1>
+      <p>This is the new, secure dashboard for HCIS Administrators. All management features will be migrated here.</p>
+    </div>
+    <?php
   }
 
   public static function render(){


### PR DESCRIPTION
## Summary
- register a Portal HCIS top-level admin menu for the manage_hcis_portal capability and provide a placeholder view
- keep the existing settings screen accessible while wiring it through add_options_page
- prioritize logged-in WordPress admins when resolving the current identity and bridge to the legacy session as a fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5f9cf001883239a4db2c6e106ed9d