### PR TITLE
Add implementation task checklist for removing redundant WordPress files

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,22 @@
+# Implementation Tasks for WordPress Core Cleanup
+
+## Preparation
+- [ ] Audit the `docker-compose.yml` volume mounts and note any entries pointing to the WordPress core files scheduled for removal.
+- [ ] Confirm that all theme and plugin customizations live under `wp-content/`.
+
+## Remove redundant WordPress core files
+- [ ] Delete the following files from the repository because the WordPress image already provides them:
+  - `license.txt`
+  - `readme.html`
+  - `index.php`
+  - `wp-blog-header.php`
+  - `wp-load.php`
+  - `wp-settings.php`
+  - `wp-config-sample.php`
+  - `.htaccess` (if present)
+- [ ] Update `docker-compose.yml` to remove volume mounts referencing the deleted files.
+
+## Verification
+- [ ] Run `docker compose up` and ensure the containers start without missing-file errors.
+- [ ] Access the local WordPress site to confirm that existing themes and plugins still work as expected.
+- [ ] Commit the changes and push them for review.


### PR DESCRIPTION
## Summary
- add a TASKS.md checklist detailing the steps for removing redundant WordPress core files from the repository
- include verification steps to ensure the docker-compose environment continues to run after the cleanup

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e5fd3e5070832382c28f5ffac2e103