### PR TITLE
Fix duplicate render_admin_portal_page definition

### DIFF
--- a/wp-content/plugins/hcis.ysq/includes/Admin.php
+++ b/wp-content/plugins/hcis.ysq/includes/Admin.php
@@ -30,18 +30,6 @@ class Admin {
    * Render the view for the new "Portal HCIS" admin page.
    */
   public static function render_admin_portal_page() {
-    ?>
-    <div class="wrap">
-      <h1>Welcome to the HCIS Portal</h1>
-      <p>This is the new, secure dashboard for HCIS Administrators. All management features will be migrated here.</p>
-    </div>
-    <?php
-  }
-
-  /**
-   * Render the view for the new "Portal HCIS" admin page.
-   */
-  public static function render_admin_portal_page() {
     if (!current_user_can('manage_hcis_portal') && !current_user_can('manage_options')) return;
 
     self::render_settings_interface();


### PR DESCRIPTION
## Summary
- remove the redundant render_admin_portal_page implementation so the Admin class only declares it once
- keep the version that checks capabilities and renders the settings interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6071388008323a714e06c18579407