### PR TITLE
Redirect HCIS admin logins to dashboard

### DIFF
--- a/wp-content/plugins/hcis.ysq/hcis.ysq.php
+++ b/wp-content/plugins/hcis.ysq/hcis.ysq.php
@@ -186,7 +186,7 @@ if (!function_exists('hcisysq_custom_login_redirect')) {
   function hcisysq_custom_login_redirect($redirect_to, $requested_redirect_to, $user) {
     if ($user && !is_wp_error($user) && isset($user->roles) && is_array($user->roles)) {
       if (in_array('hcis_admin', $user->roles, true)) {
-        return admin_url('admin.php?page=hcis-admin-portal');
+        return home_url('/dashboard');
       }
     }
 


### PR DESCRIPTION
## Summary
- update the custom login redirect so hcis_admin users land on the dashboard after signing in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60d4408f08323aa8553eb6f6a4161