### PR TITLE
Fix auth copy, honor user sheet tabs, and harden Apps Script test

### DIFF
--- a/TASK_PROPOSALS.md
+++ b/TASK_PROPOSALS.md
@@ -1,0 +1,22 @@
+# Follow-up Task Proposals
+
+## Typo Fix
+- **Issue**: The login error messages consistently misspell "Password" as "Pasword" in the authentication workflow, leading to user-facing typos.
+- **Location**: `wp-content/plugins/hcis.ysq/includes/Auth.php`
+- **Proposed Task**: Update the affected strings (and any front-end surfaces that reuse them) to use the correct spelling so the UI copy is professional and consistent.
+
+## Bug Fix
+- **Issue**: The Users import configuration allows administrators to specify a custom Google Sheets tab name, but both the saved URL helper and the manual import action hardcode `gid=0`, so any tab that is not the first sheet fails to import.
+- **Location**: `wp-content/plugins/hcis.ysq/includes/Admin.php`, `wp-content/plugins/hcis.ysq/includes/Users.php`
+- **Proposed Task**: Resolve the mismatch by either deriving the correct `gid` for the chosen tab or letting administrators supply a publish-to-web URL, ensuring imports honor the configured tab.
+
+## Documentation Discrepancy
+- **Issue**: The quickstart guide still instructs admins to fill in a "Default GAS URL" field inside the WhatsApp & SSO settings section, but the current settings screen exposes only WhatsApp fields plus the GAS API key.
+- **Location**: `wp-content/plugins/hcis.ysq/QUICKSTART-v1.2.0.md`, `wp-content/plugins/hcis.ysq/includes/Admin.php`
+- **Proposed Task**: Update the documentation (or reintroduce the missing field if it should exist) so the instructions accurately reflect the available settings.
+
+## Test Improvement
+- **Issue**: The `testPost` helper in the Google Apps Script training file merely logs the response, providing no automated verification that the webhook behaves correctly.
+- **Location**: `wp-content/plugins/hcis.ysq/docs/google-apps-script-training.js`
+- **Proposed Task**: Enhance the helper to assert on the HTTP status and parsed payload (or convert it into a small unit test) to catch regressions in the Apps Script endpoint behavior.
+

--- a/wp-content/plugins/hcis.ysq/IMPLEMENTATION-REPORT-v1.2.0.md
+++ b/wp-content/plugins/hcis.ysq/IMPLEMENTATION-REPORT-v1.2.0.md
@@ -113,7 +113,7 @@ const nonce = (window.hcisysq && hcisysq.nonce) ? hcisysq.nonce : '';
 - [ ] Klik "Keluar" → redirect ke `/`
 
 ### 3. Lupa Password
-- [ ] Klik "Lupa pasword?" di form login
+- [ ] Klik "Lupa password?" di form login
 - [ ] Input NIP → klik "Kirim"
 - [ ] Verifikasi: Response 200 OK dengan pesan sukses/gagal (bukan 400)
 - [ ] Admin HCM menerima notifikasi WA (jika konfigurasi benar)
@@ -129,7 +129,7 @@ const nonce = (window.hcisysq && hcisysq.nonce) ? hcisysq.nonce : '';
 
 ### 6. Settings
 - [ ] Admin → Tools → HCIS.YSQ Settings
-- [ ] Isi field: Admin WhatsApp, WA Token, GAS URL
+- [ ] Isi field: Admin WhatsApp, WA Token, HCIS GAS API Key
 - [ ] Klik "Simpan" → verifikasi tersimpan di `wp_options`
 
 ---

--- a/wp-content/plugins/hcis.ysq/QUICKSTART-v1.2.0.md
+++ b/wp-content/plugins/hcis.ysq/QUICKSTART-v1.2.0.md
@@ -26,7 +26,9 @@ Scroll ke **Section 4: WhatsApp & SSO Settings**, isi:
 |-------|-------|--------|
 | Admin WhatsApp | `6285175201627` | ✅ (untuk lupa password) |
 | WhatsApp API Token | `4a74d8ae-...` | ✅ (Starsender key) |
-| Default GAS URL | `https://script.google.com/.../exec` | ✅ (form pelatihan SSO) |
+| HCIS GAS API Key | `shared-secret` | ✅ (harus sama dengan Apps Script) |
+
+> **Catatan:** URL Web App Google Apps Script sekarang diisi pada **Section 3 &mdash; Training Form → Google Sheet**.
 
 Klik **Simpan**.
 
@@ -65,12 +67,12 @@ Buat/edit 2 halaman di WordPress:
 1. Buka `https://hcis.sabilulquran.or.id/`
 2. Input:
    - **Akun**: NIP pegawai (contoh: `123456`)
-   - **Pasword**: No HP (format: `628xxx` atau `08xxx`)
+   - **Password**: No HP (format: `628xxx` atau `08xxx`)
 3. Klik **"Masuk"**
 4. Jika berhasil → redirect ke `/dashboard`
 
 ### Lupa Password Test
-1. Klik **"Lupa pasword?"**
+1. Klik **"Lupa password?"**
 2. Input NIP → Klik **"Kirim"**
 3. Admin HCM akan menerima WA notifikasi
 
@@ -91,7 +93,7 @@ Buat/edit 2 halaman di WordPress:
 2. Halaman `masuk` dan `dashboard` sudah ada
 3. Home page sudah di-set di **Settings → Reading**
 
-### ❌ Tombol "Lupa pasword" tidak kirim WA
+### ❌ Tombol "Lupa password" tidak kirim WA
 **Cek**:
 1. **Settings → HCIS.YSQ** → Admin WhatsApp & Token sudah diisi
 2. Token Starsender valid dan aktif
@@ -99,7 +101,7 @@ Buat/edit 2 halaman di WordPress:
 
 ### ❌ Form Pelatihan (GAS) tidak redirect
 **Cek**:
-1. **Settings → HCIS.YSQ** → Default GAS URL sudah diisi
+1. **Settings → HCIS.YSQ** → Training → Web App URL sudah diisi
 2. Google Apps Script deployed sebagai "Web app" (Execute as: Me, Access: Anyone)
 
 ---

--- a/wp-content/plugins/hcis.ysq/assets/js/login.js
+++ b/wp-content/plugins/hcis.ysq/assets/js/login.js
@@ -25,7 +25,7 @@
       const nip = (form.nip.value || '').trim();
       const pwv = (form.pw.value || '').trim();
       if (!nip || !pwv) {
-        msg.textContent = 'Akun & Pasword wajib diisi.';
+        msg.textContent = 'Akun & Password wajib diisi.';
         return;
       }
 

--- a/wp-content/plugins/hcis.ysq/hcis.ysq.php
+++ b/wp-content/plugins/hcis.ysq/hcis.ysq.php
@@ -131,7 +131,8 @@ add_action('hcisysq_profiles_cron', function(){
 add_action('hcisysq_users_cron', function(){
   $sheet_id = \HCISYSQ\Users::get_sheet_id();
   if ($sheet_id) {
-    $url = "https://docs.google.com/spreadsheets/d/{$sheet_id}/export?format=csv&gid=0";
+    $tab_name = \HCISYSQ\Users::get_tab_name();
+    $url = \HCISYSQ\Users::build_csv_url($sheet_id, $tab_name);
     \HCISYSQ\Users::import_from_csv($url);
   }
 });

--- a/wp-content/plugins/hcis.ysq/includes/Admin.php
+++ b/wp-content/plugins/hcis.ysq/includes/Admin.php
@@ -67,7 +67,7 @@ class Admin {
         Users::set_sheet_config($sheet_id, $tab_name);
 
         if (isset($_POST['import_users']) && $sheet_id) {
-          $url = "https://docs.google.com/spreadsheets/d/{$sheet_id}/export?format=csv&gid=0";
+          $url = Users::build_csv_url($sheet_id, $tab_name);
           $res = Users::import_from_csv($url);
           $msg .= $res['ok']
             ? "<strong>Import Users:</strong> inserted {$res['inserted']}, updated {$res['updated']}.<br>"

--- a/wp-content/plugins/hcis.ysq/includes/Auth.php
+++ b/wp-content/plugins/hcis.ysq/includes/Auth.php
@@ -202,13 +202,13 @@ class Auth {
     $plain_pass = trim(strval($plain_pass));
 
     if ($account === '' || $plain_pass === '') {
-      return ['ok' => false, 'msg' => 'Akun & Pasword wajib diisi'];
+      return ['ok' => false, 'msg' => 'Akun & Password wajib diisi'];
     }
 
     $adminSettings = self::get_admin_settings();
     if (strcasecmp($account, $adminSettings['username']) === 0) {
       if (!password_verify($plain_pass, $adminSettings['password_hash'])) {
-        return ['ok' => false, 'msg' => 'Pasword administrator salah.'];
+        return ['ok' => false, 'msg' => 'Password administrator salah.'];
       }
 
       self::store_session([
@@ -254,7 +254,7 @@ class Auth {
     }
 
     if (!$passOk) {
-      return ['ok'=>false, 'msg'=>'Pasword salah. Gunakan nomor HP sebagai pasword.'];
+      return ['ok'=>false, 'msg'=>'Password salah. Gunakan nomor HP sebagai password.'];
     }
 
     self::store_session([

--- a/wp-content/plugins/hcis.ysq/includes/Forgot.php
+++ b/wp-content/plugins/hcis.ysq/includes/Forgot.php
@@ -32,7 +32,7 @@ class Forgot {
       wp_send_json(['ok' => false, 'msg' => 'Konfigurasi WhatsApp belum diatur. Hubungi admin.']);
     }
 
-    $message = "Permintaan reset pasword HCIS.YSQ\nAkun (NIP): {$nip}\nNama: {$nama}";
+    $message = "Permintaan reset password HCIS.YSQ\nAkun (NIP): {$nip}\nNama: {$nama}";
 
     $result = self::send_wa($admin_wa, $message, $wa_token);
 

--- a/wp-content/plugins/hcis.ysq/includes/View.php
+++ b/wp-content/plugins/hcis.ysq/includes/View.php
@@ -20,14 +20,14 @@ class View {
           <label for="hcisysq-nip">Akun <span class="req">*</span></label>
           <input id="hcisysq-nip" type="text" name="nip" placeholder="Masukkan NIP" autocomplete="username" required>
 
-          <label for="hcisysq-pw">Pasword <span class="req">*</span></label>
+          <label for="hcisysq-pw">Password <span class="req">*</span></label>
           <div class="pw-row">
             <input id="hcisysq-pw" type="password" name="pw" placeholder="Gunakan No HP" autocomplete="current-password" required>
             <button type="button" id="hcisysq-eye" class="eye">lihat</button>
           </div>
 
           <button type="submit" class="btn-primary">Masuk</button>
-          <button type="button" id="hcisysq-forgot" class="link-forgot">Lupa pasword?</button>
+          <button type="button" id="hcisysq-forgot" class="link-forgot">Lupa password?</button>
           <div class="msg" aria-live="polite"></div>
         </form>
       </div>
@@ -35,7 +35,7 @@ class View {
     <div id="hcisysq-modal" class="modal-backdrop" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="hcisysq-forgot-title">
       <div class="modal">
         <button type="button" class="modal-close" id="hcisysq-close-modal" aria-label="Tutup">×</button>
-        <h3 id="hcisysq-forgot-title">Lupa Pasword</h3>
+        <h3 id="hcisysq-forgot-title">Lupa Password</h3>
         <p>Masukkan Akun (NIP) Anda. Kami akan mengirim permintaan ke Admin HCM.</p>
         <label>Akun (NIP)</label>
         <input id="hcisysq-nip-forgot" type="text" placeholder="Masukkan NIP">


### PR DESCRIPTION
## Summary
- correct the "Password" spelling across authentication responses, UI strings, and onboarding docs
- honor the configured Google Sheet tab when importing users by generating gviz CSV URLs and surfacing clearer errors
- add real assertions to the Google Apps Script `testPost` helper and align implementation docs with the current settings screen

## Testing
- php -l wp-content/plugins/hcis.ysq/includes/Users.php
- php -l wp-content/plugins/hcis.ysq/includes/Auth.php
- php -l wp-content/plugins/hcis.ysq/includes/Forgot.php
- php -l wp-content/plugins/hcis.ysq/includes/Admin.php
- php -l wp-content/plugins/hcis.ysq/includes/View.php
- php -l wp-content/plugins/hcis.ysq/hcis.ysq.php


------
https://chatgpt.com/codex/tasks/task_e_68e68b92946083239d3e6f6809049c24